### PR TITLE
Add default group permissions.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -44,6 +44,16 @@
 		"gadgets-edit",
 		"gadgets-definition-edit"
 	],
+	"GroupPermissions": {
+		"gadgeteditor": {
+			"gadgets-edit": true,
+			"gadgets-definition-edit": true
+		},
+		"interface-admin": {
+			"gadgets-edit": true,
+			"gadgets-definition-edit": true
+		}
+	},
 	"SpecialPages": {
 		"Gadgets": "SpecialGadgets",
 		"GadgetUsage": "SpecialGadgetUsage"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -34,5 +34,8 @@
 	"right-gadgets-edit": "Edit gadget JavaScript and CSS pages",
 	"action-gadgets-edit": "edit this gadget JavaScript or CSS page",
 	"right-gadgets-definition-edit": "Edit gadget definitions",
-	"action-gadgets-definition-edit": "edit this gadget definition"
+	"action-gadgets-definition-edit": "edit this gadget definition",
+	"group-gadgeteditor": "Gadget editors",
+	"group-gadgeteditor-member": "{{GENDER:$1|gadget editor}}",
+	"grouppage-gadgeteditor": "{{ns:project}}:Gadget editors"
 }


### PR DESCRIPTION
I would like to suggest the addition of a default configuration for group permissions. Adding the "gadgets-edit" and "gadgets-definition-edit" rights to "interface-admin" would allow Interface administrators to edit gadgets and their definitions. Adding a "Gadget editors" group would allow Bureaucrats to grant users the ability to edit in the "Gadget" and "GadgetDefinition" namespace without giving them full Interface administrator rights.